### PR TITLE
TE-417 Added functionality to get product abstract ids by product concrete ids

### DIFF
--- a/src/Spryker/Zed/Product/Business/Product/ProductConcreteManager.php
+++ b/src/Spryker/Zed/Product/Business/Product/ProductConcreteManager.php
@@ -337,6 +337,20 @@ class ProductConcreteManager extends AbstractProductConcreteManagerSubject imple
         return $productConcreteIds->getData();
     }
 
+    /**
+     * @param int[] $productConcreteIds
+     *
+     * @return int[]
+     */
+    public function getProductAbstractIdsByProductConcreteIds(array $productConcreteIds): array
+    {
+        return $this->productQueryContainer
+            ->queryProduct()
+            ->select([SpyProductTableMap::COL_FK_PRODUCT_ABSTRACT, SpyProductTableMap::COL_ID_PRODUCT])
+            ->filterByIdProduct_In($productConcreteIds)
+            ->find()
+            ->toKeyValue(SpyProductTableMap::COL_ID_PRODUCT, SpyProductTableMap::COL_FK_PRODUCT_ABSTRACT);
+    }
 
     /**
      * @param \Generated\Shared\Transfer\ProductConcreteTransfer $productConcreteTransfer

--- a/src/Spryker/Zed/Product/Business/Product/ProductConcreteManagerInterface.php
+++ b/src/Spryker/Zed/Product/Business/Product/ProductConcreteManagerInterface.php
@@ -99,4 +99,11 @@ interface ProductConcreteManagerInterface
      * @return int[]
      */
     public function findProductConcreteIdsByAbstractProductId(int $idProductAbstract);
+
+    /**
+     * @param int[] $productConcreteIds
+     *
+     * @return int[]
+     */
+    public function getProductAbstractIdsByProductConcreteIds(array $productConcreteIds): array;
 }

--- a/src/Spryker/Zed/Product/Business/ProductFacade.php
+++ b/src/Spryker/Zed/Product/Business/ProductFacade.php
@@ -840,4 +840,20 @@ class ProductFacade extends AbstractFacade implements ProductFacadeInterface
             ->createProductConcreteManager()
             ->findProductConcreteIdsByAbstractProductId($idProductAbstract);
     }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @api
+     *
+     * @param int[] $productConcreteIds
+     *
+     * @return int[]
+     */
+    public function getProductAbstractIdsByProductConcreteIds(array $productConcreteIds): array
+    {
+        return $this->getFactory()
+            ->createProductConcreteManager()
+            ->getProductAbstractIdsByProductConcreteIds($productConcreteIds);
+    }
 }

--- a/src/Spryker/Zed/Product/Business/ProductFacadeInterface.php
+++ b/src/Spryker/Zed/Product/Business/ProductFacadeInterface.php
@@ -733,4 +733,17 @@ interface ProductFacadeInterface
      * @return int
      */
     public function getProductAbstractIdByConcreteId(int $idProductConcrete): int;
+
+    /**
+     * Specification:
+     * - Returns an array of abstract product ids for the passed concrete product ids.
+     * - Returns a map, where each key is a concrete product id and its value is a corresponding abstract product id.
+     *
+     * @api
+     *
+     * @param int[] $productConcreteIds
+     *
+     * @return int[]
+     */
+    public function getProductAbstractIdsByProductConcreteIds(array $productConcreteIds): array;
 }


### PR DESCRIPTION
- Developer(s): @asaulenko

- Ticket: https://spryker.atlassian.net/browse/TE-417

- Academy PR: ACADEMY_URL_HERE

- Release Group: https://release.spryker.com/release-groups/view/650


#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Product               | minor                 |                       |

#### Release Notes

Added the ability to get an array of abstract product ids by an array of concrete product ids.

-----------------------------------------

#### Module Product

_**Minor:** Added functionality in a backwards-compatible manner_

Def of done (by responsible developer):
- [ ] All changes are backward-compatible. Outdated code is marked as deprecated.
- [ ] New and changed facade methods covered by functional tests. / Has nothing to test.
- [ ] New and changed complex business logic is covered by unit or integration tests. / Has nothing to test.

##### Change log

Improvements

- Introduced `ProductFacadeInterface::getProductAbstractIdsByProductConcreteIds()` for getting an array of abstract product ids by concrete product ids. 

