### PR TITLE
TE-7332 Backport for facade method isProductConcreteActive

### DIFF
--- a/src/Spryker/Zed/Product/Business/Product/Status/ProductConcreteStatusChecker.php
+++ b/src/Spryker/Zed/Product/Business/Product/Status/ProductConcreteStatusChecker.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\Product\Business\Product\Status;
+
+use Generated\Shared\Transfer\ProductConcreteTransfer;
+use Spryker\Zed\Product\Persistence\ProductRepositoryInterface;
+
+class ProductConcreteStatusChecker implements ProductConcreteStatusCheckerInterface
+{
+    /**
+     * @var \Spryker\Zed\Product\Persistence\ProductRepositoryInterface
+     */
+    protected $productRepository;
+
+    /**
+     * @param \Spryker\Zed\Product\Persistence\ProductRepositoryInterface $productRepository
+     */
+    public function __construct(ProductRepositoryInterface $productRepository)
+    {
+        $this->productRepository = $productRepository;
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\ProductConcreteTransfer $productConcreteTransfer
+     *
+     * @return bool
+     */
+    public function isActive(ProductConcreteTransfer $productConcreteTransfer): bool
+    {
+        return $this->productRepository->isProductConcreteActive($productConcreteTransfer);
+    }
+}

--- a/src/Spryker/Zed/Product/Business/Product/Status/ProductConcreteStatusCheckerInterface.php
+++ b/src/Spryker/Zed/Product/Business/Product/Status/ProductConcreteStatusCheckerInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\Product\Business\Product\Status;
+
+use Generated\Shared\Transfer\ProductConcreteTransfer;
+
+interface ProductConcreteStatusCheckerInterface
+{
+    /**
+     * @param \Generated\Shared\Transfer\ProductConcreteTransfer $productConcreteTransfer
+     *
+     * @return bool
+     */
+    public function isActive(ProductConcreteTransfer $productConcreteTransfer): bool;
+}

--- a/src/Spryker/Zed/Product/Business/ProductBusinessFactory.php
+++ b/src/Spryker/Zed/Product/Business/ProductBusinessFactory.php
@@ -162,7 +162,7 @@ class ProductBusinessFactory extends AbstractBusinessFactory
      */
     public function createProductAbstractStatusChecker()
     {
-        return new ProductAbstractStatusChecker($this->getQueryContainer(), $this->getRepository());
+        return new ProductAbstractStatusChecker($this->getQueryContainer());
     }
 
     /**

--- a/src/Spryker/Zed/Product/Business/ProductBusinessFactory.php
+++ b/src/Spryker/Zed/Product/Business/ProductBusinessFactory.php
@@ -32,6 +32,8 @@ use Spryker\Zed\Product\Business\Product\ProductConcreteManager;
 use Spryker\Zed\Product\Business\Product\ProductManager;
 use Spryker\Zed\Product\Business\Product\Sku\SkuGenerator;
 use Spryker\Zed\Product\Business\Product\Status\ProductAbstractStatusChecker;
+use Spryker\Zed\Product\Business\Product\Status\ProductConcreteStatusChecker;
+use Spryker\Zed\Product\Business\Product\Status\ProductConcreteStatusCheckerInterface;
 use Spryker\Zed\Product\Business\Product\Suggest\ProductSuggester;
 use Spryker\Zed\Product\Business\Product\Suggest\ProductSuggesterInterface;
 use Spryker\Zed\Product\Business\Product\Touch\ProductAbstractTouch;
@@ -47,6 +49,7 @@ use Spryker\Zed\Product\ProductDependencyProvider;
 /**
  * @method \Spryker\Zed\Product\ProductConfig getConfig()
  * @method \Spryker\Zed\Product\Persistence\ProductQueryContainerInterface getQueryContainer()
+ * @method \Spryker\Zed\Product\Persistence\ProductRepositoryInterface getRepository()
  */
 class ProductBusinessFactory extends AbstractBusinessFactory
 {
@@ -159,7 +162,15 @@ class ProductBusinessFactory extends AbstractBusinessFactory
      */
     public function createProductAbstractStatusChecker()
     {
-        return new ProductAbstractStatusChecker($this->getQueryContainer());
+        return new ProductAbstractStatusChecker($this->getQueryContainer(), $this->getRepository());
+    }
+
+    /**
+     * @return \Spryker\Zed\Product\Business\Product\Status\ProductConcreteStatusCheckerInterface
+     */
+    public function createProductConcreteStatusChecker(): ProductConcreteStatusCheckerInterface
+    {
+        return new ProductConcreteStatusChecker($this->getRepository());
     }
 
     /**

--- a/src/Spryker/Zed/Product/Business/ProductFacade.php
+++ b/src/Spryker/Zed/Product/Business/ProductFacade.php
@@ -704,6 +704,22 @@ class ProductFacade extends AbstractFacade implements ProductFacadeInterface
     }
 
     /**
+     * {@inheritDoc}
+     *
+     * @api
+     *
+     * @param \Generated\Shared\Transfer\ProductConcreteTransfer $productConcreteTransfer
+     *
+     * @return bool
+     */
+    public function isProductConcreteActive(ProductConcreteTransfer $productConcreteTransfer): bool
+    {
+        return $this->getFactory()
+            ->createProductConcreteStatusChecker()
+            ->isActive($productConcreteTransfer);
+    }
+
+    /**
      * {@inheritdoc}
      *
      * @api

--- a/src/Spryker/Zed/Product/Business/ProductFacadeInterface.php
+++ b/src/Spryker/Zed/Product/Business/ProductFacadeInterface.php
@@ -625,6 +625,18 @@ interface ProductFacadeInterface
 
     /**
      * Specification:
+     * - Returns true if concrete product is active.
+     *
+     * @api
+     *
+     * @param \Generated\Shared\Transfer\ProductConcreteTransfer $productConcreteTransfer
+     *
+     * @return bool
+     */
+    public function isProductConcreteActive(ProductConcreteTransfer $productConcreteTransfer): bool;
+
+    /**
+     * Specification:
      * - Returns an array with attribute keys of a persisted product.
      * - The result is a combination of the abstract product's attribute keys and all its existing concretes' attribute keys.
      * - If $localeTransfer is provided then localized abstract and concrete attribute keys are also part of the result.

--- a/src/Spryker/Zed/Product/Persistence/ProductRepository.php
+++ b/src/Spryker/Zed/Product/Persistence/ProductRepository.php
@@ -12,6 +12,7 @@ use Generated\Shared\Transfer\LocaleTransfer;
 use Generated\Shared\Transfer\PaginationTransfer;
 use Generated\Shared\Transfer\ProductAbstractSuggestionCollectionTransfer;
 use Generated\Shared\Transfer\ProductAbstractTransfer;
+use Generated\Shared\Transfer\ProductConcreteTransfer;
 use Orm\Zed\Product\Persistence\Map\SpyProductAbstractLocalizedAttributesTableMap;
 use Orm\Zed\Product\Persistence\Map\SpyProductAbstractTableMap;
 use Orm\Zed\Product\Persistence\SpyProductAbstractQuery;
@@ -26,6 +27,19 @@ use Spryker\Zed\PropelOrm\Business\Runtime\ActiveQuery\Criteria;
 class ProductRepository extends AbstractRepository implements ProductRepositoryInterface
 {
     public const KEY_FILTERED_PRODUCTS_PRODUCT_NAME = 'name';
+
+    /**
+     * @param \Generated\Shared\Transfer\ProductConcreteTransfer $productConcreteTransfer
+     *
+     * @return bool
+     */
+    public function isProductConcreteActive(ProductConcreteTransfer $productConcreteTransfer): bool
+    {
+        return $this->getFactory()
+            ->createProductQuery()
+            ->findOneBySku($productConcreteTransfer->getSku())
+            ->getIsActive();
+    }
 
     /**
      * @param string $search

--- a/src/Spryker/Zed/Product/Persistence/ProductRepositoryInterface.php
+++ b/src/Spryker/Zed/Product/Persistence/ProductRepositoryInterface.php
@@ -10,9 +10,18 @@ namespace Spryker\Zed\Product\Persistence;
 use Generated\Shared\Transfer\LocaleTransfer;
 use Generated\Shared\Transfer\PaginationTransfer;
 use Generated\Shared\Transfer\ProductAbstractSuggestionCollectionTransfer;
+use Generated\Shared\Transfer\ProductConcreteTransfer;
 
 interface ProductRepositoryInterface
 {
+
+    /**
+     * @param \Generated\Shared\Transfer\ProductConcreteTransfer $productConcreteTransfer
+     *
+     * @return bool
+     */
+    public function isProductConcreteActive(ProductConcreteTransfer $productConcreteTransfer): bool;
+
     /**
      * @param string $search
      * @param \Generated\Shared\Transfer\PaginationTransfer $paginationTransfer


### PR DESCRIPTION
## PR Description

- Developer(s): @bezpiatovs

- Ticket: https://spryker.atlassian.net/browse/TE-7332

- Release Group: https://release.spryker.com/release-groups/view/3118

- PR Overview: https://release.spryker.com/release/hotfix?type=&pr=https%3A%2F%2Fgithub.com%2Fspryker%2Fproduct%2Fpull%2F5

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Product  | minor                 |                       |
-----------------------------------------

#### Module Product

##### Change log

Fixes

- Introduced a facade method `ProductFacade::isProductConcreteActive()`.