### PR TITLE
CC-14561 Backport for facade method getRawProductAbstractTransfersByA…

### DIFF
--- a/src/Spryker/Zed/Product/Business/ProductFacade.php
+++ b/src/Spryker/Zed/Product/Business/ProductFacade.php
@@ -18,6 +18,7 @@ use Spryker\Zed\Kernel\Business\AbstractFacade;
 
 /**
  * @method \Spryker\Zed\Product\Business\ProductBusinessFactory getFactory()
+ * @method \Spryker\Zed\Product\Persistence\ProductRepositoryInterface getRepository()
  */
 class ProductFacade extends AbstractFacade implements ProductFacadeInterface
 {
@@ -890,5 +891,19 @@ class ProductFacade extends AbstractFacade implements ProductFacadeInterface
         return $this->getFactory()
             ->createProductConcreteManager()
             ->getProductAbstractIdsByProductConcreteIds($productConcreteIds);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @api
+     *
+     * @param array<string> $productAbstractSkus
+     *
+     * @return array<\Generated\Shared\Transfer\ProductAbstractTransfer>
+     */
+    public function getRawProductAbstractTransfersByAbstractSkus(array $productAbstractSkus): array
+    {
+        return $this->getRepository()->getRawProductAbstractTransfersByAbstractSkus($productAbstractSkus);
     }
 }

--- a/src/Spryker/Zed/Product/Business/ProductFacadeInterface.php
+++ b/src/Spryker/Zed/Product/Business/ProductFacadeInterface.php
@@ -774,4 +774,17 @@ interface ProductFacadeInterface
      * @return int[]
      */
     public function getProductAbstractIdsByProductConcreteIds(array $productConcreteIds): array;
+
+    /**
+     * Specification:
+     * - Retrieves product abstract transfer by sku.
+     * - Doesn't populate it with additional data.
+     *
+     * @api
+     *
+     * @param array<string> $productAbstractSkus
+     *
+     * @return array<\Generated\Shared\Transfer\ProductAbstractTransfer>
+     */
+    public function getRawProductAbstractTransfersByAbstractSkus(array $productAbstractSkus): array;
 }

--- a/src/Spryker/Zed/Product/Persistence/Mapper/ProductMapper.php
+++ b/src/Spryker/Zed/Product/Persistence/Mapper/ProductMapper.php
@@ -29,4 +29,17 @@ class ProductMapper implements ProductMapperInterface
 
         return $productAbstractTransfer;
     }
+
+    /**
+     * @param \Orm\Zed\Product\Persistence\SpyProductAbstract $productAbstractEntity
+     * @param \Generated\Shared\Transfer\ProductAbstractTransfer $productAbstractTransfer
+     *
+     * @return \Generated\Shared\Transfer\ProductAbstractTransfer
+     */
+    public function mapProductAbstractEntityToProductAbstractTransferWithoutRelations(
+        SpyProductAbstract $productAbstractEntity,
+        ProductAbstractTransfer $productAbstractTransfer
+    ): ProductAbstractTransfer {
+        return $productAbstractTransfer->fromArray($productAbstractEntity->toArray(), true);
+    }
 }

--- a/src/Spryker/Zed/Product/Persistence/Mapper/ProductMapperInterface.php
+++ b/src/Spryker/Zed/Product/Persistence/Mapper/ProductMapperInterface.php
@@ -22,4 +22,15 @@ interface ProductMapperInterface
         SpyProductAbstract $productAbstractEntity,
         ProductAbstractTransfer $productAbstractTransfer
     ): ProductAbstractTransfer;
+
+    /**
+     * @param \Orm\Zed\Product\Persistence\SpyProductAbstract $productAbstractEntity
+     * @param \Generated\Shared\Transfer\ProductAbstractTransfer $productAbstractTransfer
+     *
+     * @return \Generated\Shared\Transfer\ProductAbstractTransfer
+     */
+    public function mapProductAbstractEntityToProductAbstractTransferWithoutRelations(
+        SpyProductAbstract $productAbstractEntity,
+        ProductAbstractTransfer $productAbstractTransfer
+    ): ProductAbstractTransfer;
 }

--- a/src/Spryker/Zed/Product/Persistence/ProductRepository.php
+++ b/src/Spryker/Zed/Product/Persistence/ProductRepository.php
@@ -85,6 +85,40 @@ class ProductRepository extends AbstractRepository implements ProductRepositoryI
     }
 
     /**
+     * @param array<string> $productAbstractSkus
+     *
+     * @return array<\Generated\Shared\Transfer\ProductAbstractTransfer>
+     */
+    public function getRawProductAbstractTransfersByAbstractSkus(array $productAbstractSkus): array
+    {
+        $productAbstractEntities = $this->getFactory()->createProductAbstractQuery()
+            ->filterBySku_In($productAbstractSkus)
+            ->find();
+
+        return $this->mapProductAbstractEntitiesToProductAbstractTransfersWithoutRelations($productAbstractEntities);
+    }
+
+    /**
+     * @param \Propel\Runtime\Collection\ObjectCollection|\Orm\Zed\Product\Persistence\SpyProductAbstract[] $productAbstractEntities
+     *
+     * @return array<\Generated\Shared\Transfer\ProductAbstractTransfer>
+     */
+    protected function mapProductAbstractEntitiesToProductAbstractTransfersWithoutRelations(ObjectCollection $productAbstractEntities): array
+    {
+        $productAbstractTransfers = [];
+        $mapper = $this->getFactory()->createProductMapper();
+
+        foreach ($productAbstractEntities as $productAbstractEntity) {
+            $productAbstractTransfers[] = $mapper->mapProductAbstractEntityToProductAbstractTransferWithoutRelations(
+                $productAbstractEntity,
+                new ProductAbstractTransfer()
+            );
+        }
+
+        return $productAbstractTransfers;
+    }
+
+    /**
      * @param \Orm\Zed\Product\Persistence\SpyProductAbstractQuery $spyProductAbstractQuery
      * @param \Generated\Shared\Transfer\PaginationTransfer $paginationTransfer
      *

--- a/src/Spryker/Zed/Product/Persistence/ProductRepositoryInterface.php
+++ b/src/Spryker/Zed/Product/Persistence/ProductRepositoryInterface.php
@@ -34,4 +34,11 @@ interface ProductRepositoryInterface
         PaginationTransfer $paginationTransfer,
         LocaleTransfer $localeTransfer
     ): ProductAbstractSuggestionCollectionTransfer;
+
+    /**
+     * @param array<string> $productAbstractSkus
+     *
+     * @return array<\Generated\Shared\Transfer\ProductAbstractTransfer>
+     */
+    public function getRawProductAbstractTransfersByAbstractSkus(array $productAbstractSkus): array;
 }


### PR DESCRIPTION
Branch: backport/cc-14561/product-5.10.0
Ticket: https://spryker.atlassian.net/browse/CC-14561
Target Version: 5.10.0

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Product  | minor                 |                       |
-----------------------------------------

#### Release Notes

{skip}

-----------------------------------------

#### Module Product

##### Change log

Improvements

- Introduced `ProductFacadeInterface::getRawProductAbstractTransfersByAbstractSkus()` that returns collection of `ProductAbstractTransfer` by set of skus without any related data.
