### PR TITLE
use $productAbstractOverride instead of $productConcreteOverride when using haveProductAbstract helper method

### DIFF
--- a/tests/SprykerTest/Shared/Product/_support/Helper/ProductDataHelper.php
+++ b/tests/SprykerTest/Shared/Product/_support/Helper/ProductDataHelper.php
@@ -112,7 +112,7 @@ class ProductDataHelper extends Module
             $localizedAttributes = (new LocalizedAttributesBuilder([
                 LocalizedAttributesTransfer::NAME => uniqid('Product #', true),
                 LocalizedAttributesTransfer::LOCALE => $this->getCurrentLocale(),
-                LocalizedAttributesTransfer::ATTRIBUTES => $productConcreteOverride[ProductConcreteTransfer::ATTRIBUTES] ?? [],
+                LocalizedAttributesTransfer::ATTRIBUTES => $productAbstractOverride[ProductAbstractTransfer::ATTRIBUTES] ?? [],
             ]))->build()->toArray();
 
             $productAbstractTransfer->withLocalizedAttributes($localizedAttributes);


### PR DESCRIPTION
$productConcreteOverride does not exist in ProductDataHelper::haveProductAbstract method